### PR TITLE
TRUNK-5699 Deprecate Attributable#findPossibleValues() and Attributable#getPossibleValues()

### DIFF
--- a/api/src/main/java/org/openmrs/module/tribe/Tribe.java
+++ b/api/src/main/java/org/openmrs/module/tribe/Tribe.java
@@ -128,6 +128,7 @@ public class Tribe extends BaseOpenmrsMetadata implements java.io.Serializable, 
     /**
 	 * @see org.openmrs.Attributable#findPossibleValues(java.lang.String)
 	 */
+	@Deprecated
 	public List<Tribe> findPossibleValues(String searchText) {
 		try {
 			return ((TribeService) Context.getService(TribeService.class)).findTribes(searchText);
@@ -140,6 +141,7 @@ public class Tribe extends BaseOpenmrsMetadata implements java.io.Serializable, 
 	/**
 	 * @see org.openmrs.Attributable#getPossibleValues()
 	 */
+	@Deprecated
 	public List<Tribe> getPossibleValues() {
 		try {
 			return ((TribeService) Context.getService(TribeService.class)).getTribes();


### PR DESCRIPTION
## Description of what I changed
Deprecated the methods `Attributable#findPossibleValues()` and `Attributable#getPossibleValues()`


## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-5699